### PR TITLE
Enable integration tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false
 
 jdk:
   - oraclejdk7
+  
+script:
+  - mvn verify
 
 notifications:
   slack:


### PR DESCRIPTION
It appears with default Travis CI configuration we are only running **mvn test** need to move to **mvn verify** so we include the integration cycle and make sure it works on Travis CI.
