### PR TITLE
Enable snapshot uploads on travis plus others

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ jdk:
 script:
   - mvn verify
 
+after_success:
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && mvn deploy || false'
+
 notifications:
   slack:
     secure: "g3zr8QxdJdMvaQnYEDfa13oOlseYGPm8IXUAURnu+oNdBMXzvB7yYDCBp/c9kF0QJTwLWOqrGnJyBK3hE4cWJFt+hdvQMXWSVJb4mf3gICDv4s5sVzvvY+Lh/TadiS5tsM1wZZjhIbCkc2HAjM/J3+YOtN/oK6cyOudDJBPByzEjW/PF5/At6ZyMVQo0bOga+zpZhIKVC2L6w4rtXiCh7FsUo7qV+svRxRK8Qm+rsvV3Qp8wpRjSk5HaPVw4L4eOPkMvFyDIhW6HJldtUU8cF4Tabb7whKcjHtNW0t5i+WAlfd0uOdVBNMrw4aMsIJdlgY33TlPVNGHi7YGL4ht22dScfQNtZhGKXgqoS/nFahmLzXDs8rv8RyC4T96Eumb8tPq4ii6eG3j5+FqxMwOuuU93CxijvsSYbqQmwECNphYAm1ftyb4R5cFYAZ/4EFc6tn7KfpF3FZ6YB6W6vj9Q9VOVjxofPR/MAqOGl9Kqe380zvgpg7Oef/cRb2dqT7pi61QzX/gwsvIlRake+n1WI1xobNeC6Msj+6e5uYkpDyJpJZzzPYtAPab3xZvXQGy+53Ykohuxxa+9jR9ybfcdkjPfWKV10EZBvmxw8s2IL/V1dR2ZtBjCibaHIxp60tn4FzuCQWeSEbSJVVpibU8YtkxIpLSoklALjEejDz5GX20="

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -9,109 +10,89 @@
 
     <artifactId>substeps-core-api</artifactId>
 
-    <packaging>jar</packaging>
-
-
-    <properties>
-      <guava.version>10.0</guava.version>
-    </properties>
-
     <name>SubSteps API</name>
-    
-    <organization>
-        <name>Technophobia Ltd</name>
-        <url>www.technophobia.com/</url>
-    </organization>
 
-    <licenses>
-        <license>
-            <name>LGPL 3.0 license</name>
-            <url>http://www.opensource.org/licenses/lgpl-3.0.html</url>
-            <distribution>manual</distribution>
-      </license>
-    </licenses>
-    
     <developers>
-   
+
         <developer>
-          <id>ianmoore</id>
-          <name>Ian Moore</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>architect</role>
-            <role>developer</role>
-          </roles>
+            <id>ianmoore</id>
+            <name>Ian Moore</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>architect</role>
+                <role>developer</role>
+            </roles>
         </developer>
 
         <developer>
-          <id>rorygibson</id>
-          <name>Rory Gibson</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
+            <id>rorygibson</id>
+            <name>Rory Gibson</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
         </developer>
 
         <developer>
-          <id>davemoss</id>
-          <name>Dave Moss</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
+            <id>davemoss</id>
+            <name>Dave Moss</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
         </developer>
-  
-       <developer>
-          <id>stuartforbes</id>
-          <name>Stu Forbes</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
+
+        <developer>
+            <id>stuartforbes</id>
+            <name>Stu Forbes</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
         </developer>
-		
-       <developer>
-          <id>rickybarefield</id>
-          <name>Ricky Barefield</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
-       </developer>
-       
-       <developer>
-          <id>beercan1989</id>
-          <name>James Bacon</name>
-          <organization>G2G3 Digital</organization>
-          <url>https://github.com/beercan1989</url>
-          <roles>
-            <role>developer</role>
-          </roles>
+
+        <developer>
+            <id>rickybarefield</id>
+            <name>Ricky Barefield</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
         </developer>
-	  
+
+        <developer>
+            <id>beercan1989</id>
+            <name>James Bacon</name>
+            <organization>G2G3 Digital</organization>
+            <url>https://github.com/beercan1989</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+
     </developers>
 
-	<contributors>
-		<contributor>
-			<name>Iain Rawson</name>
-			<roles>
-				<role>developer</role>
-			</roles>
-		</contributor>
-	</contributors>
-    
+    <contributors>
+        <contributor>
+            <name>Iain Rawson</name>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </contributor>
+    </contributors>
 
-
-    
+    <properties>
+        <guava.version>10.0</guava.version>
+    </properties>
 
     <dependencies>
 
-		<dependency>
-		    <groupId>commons-configuration</groupId>
-		    <artifactId>commons-configuration</artifactId>
-		    <version>1.8</version>
-		</dependency>
-		
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+            <version>1.8</version>
+        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -123,7 +104,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.6.4</version>
-           <scope>test</scope>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -150,39 +131,16 @@
             <artifactId>annotations</artifactId>
             <version>1.3.2</version>
         </dependency>
-        
+
     </dependencies>
 
     <build>
         <finalName>${project.artifactId}</finalName>
+
         <plugins>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.3.2</version>
-
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
                 <executions>
                     <execution>
                         <goals>
@@ -191,42 +149,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
-
-
-
-    <profiles>
-        
-        <!-- A profile used by default for internal dev, using the repos set up in proeprties defined above, rather than the OSS nexus repos -->    
-        <profile>
-            <id>internalDev</id>
-             
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>${nexus.snapshot.artifacts}</id>
-                    <name>${nexus.snapshot.artifacts}</name>
-                    <url>${nexus.snapshot.url}</url>
-                    <uniqueVersion>false</uniqueVersion>
-                </snapshotRepository>
-                <repository>
-                    <id>${nexus.release.artifacts}</id>
-                    <name>${nexus.release.artifacts}</name>
-                    <url>${nexus.releases.url}</url>
-                </repository>
-            </distributionManagement>
-            
-        </profile>
-        
-     
-    </profiles>
-
-    <scm>
-        <connection>${substeps-core-api.scm}</connection>
-        <developerConnection>${substeps-core-api.scm}</developerConnection>
-        <url>${substeps-core-api.scm.url}</url>
-      <tag>HEAD</tag>
-  </scm>
-
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -12,57 +12,41 @@
 
     <name>SubSteps API</name>
 
-    <properties>
-        <guava.version>10.0</guava.version>
-    </properties>
-
     <dependencies>
-
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
-            <version>1.8</version>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.4</version>
-            <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.4</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-        </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
-
         <dependency>
             <groupId>net.sourceforge.findbugs</groupId>
             <artifactId>annotations</artifactId>
-            <version>1.3.2</version>
         </dependency>
 
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <!-- Test Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -12,75 +12,6 @@
 
     <name>SubSteps API</name>
 
-    <developers>
-
-        <developer>
-            <id>ianmoore</id>
-            <name>Ian Moore</name>
-            <organization>Technophobia</organization>
-            <roles>
-                <role>architect</role>
-                <role>developer</role>
-            </roles>
-        </developer>
-
-        <developer>
-            <id>rorygibson</id>
-            <name>Rory Gibson</name>
-            <organization>Technophobia</organization>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-
-        <developer>
-            <id>davemoss</id>
-            <name>Dave Moss</name>
-            <organization>Technophobia</organization>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-
-        <developer>
-            <id>stuartforbes</id>
-            <name>Stu Forbes</name>
-            <organization>Technophobia</organization>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-
-        <developer>
-            <id>rickybarefield</id>
-            <name>Ricky Barefield</name>
-            <organization>Technophobia</organization>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-
-        <developer>
-            <id>beercan1989</id>
-            <name>James Bacon</name>
-            <organization>G2G3 Digital</organization>
-            <url>https://github.com/beercan1989</url>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-
-    </developers>
-
-    <contributors>
-        <contributor>
-            <name>Iain Rawson</name>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </contributor>
-    </contributors>
-
     <properties>
         <guava.version>10.0</guava.version>
     </properties>
@@ -135,8 +66,6 @@
     </dependencies>
 
     <build>
-        <finalName>${project.artifactId}</finalName>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,86 +12,7 @@
 
     <name>SubSteps Core</name>
 
-    <developers>
-
-        <developer>
-          <id>iantmoore</id>
-          <name>Ian Moore</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>architect</role>
-            <role>developer</role>
-          </roles>
-        </developer>
-
-        <developer>
-          <id>rorygibson</id>
-          <name>Rory Gibson</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
-        </developer>
-
-        <developer>
-          <id>davemoss</id>
-          <name>Dave Moss</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
-        </developer>
-
-       <developer>
-          <id>stuartforbes</id>
-          <name>Stu Forbes</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
-        </developer>
-
-		<developer>
-			<id>rickybarefield</id>
-			<name>Ricky Barefield</name>
-			<organization>Technophobia</organization>
-			<roles>
-				<role>developer</role>
-			</roles>
-		</developer>
-
-      <developer>
-          <id>petergphillips</id>
-          <name>Peter Phillips</name>
-          <organization>Greenthistle.com</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
-       </developer>
-
-       <developer>
-          <id>beercan1989</id>
-          <name>James Bacon</name>
-          <organization>G2G3 Digital</organization>
-          <url>https://github.com/beercan1989</url>
-          <roles>
-            <role>developer</role>
-          </roles>
-        </developer>
-
-    </developers>
-
-	<contributors>
-		<contributor>
-			<name>Iain Rawson</name>
-			<roles>
-				<role>developer</role>
-			</roles>
-		</contributor>
-	</contributors>
-
     <properties>
-
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.11</junit.version>
 
@@ -106,7 +27,6 @@
         <sonar.jacoco.reportPath>${basedir}/target/jacoco.exec</sonar.jacoco.reportPath>
 
         <xstream.version>1.4.2</xstream.version>
-
     </properties>
 
     <dependencies>
@@ -239,8 +159,6 @@
 
 
     <build>
-        <finalName>${project.artifactId}</finalName>
-
         <plugins>
             <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -275,7 +193,6 @@
 
         </plugins>
     </build>
-
 
     <reporting>
         <plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -9,26 +10,10 @@
 
     <artifactId>substeps-core</artifactId>
 
-    <packaging>jar</packaging>
+    <name>SubSteps Core</name>
 
-
-    <name>SubSteps</name>
-    
-    <organization>
-        <name>Technophobia Ltd</name>
-        <url>www.technophobia.com/</url>
-    </organization>
-
-    <licenses>
-        <license>
-            <name>LGPL 3.0 license</name>
-            <url>http://www.opensource.org/licenses/lgpl-3.0.html</url>
-            <distribution>manual</distribution>
-      </license>
-    </licenses>
-    
     <developers>
-   
+
         <developer>
           <id>iantmoore</id>
           <name>Ian Moore</name>
@@ -56,7 +41,7 @@
             <role>developer</role>
           </roles>
         </developer>
-  
+
        <developer>
           <id>stuartforbes</id>
           <name>Stu Forbes</name>
@@ -65,7 +50,7 @@
             <role>developer</role>
           </roles>
         </developer>
-		
+
 		<developer>
 			<id>rickybarefield</id>
 			<name>Ricky Barefield</name>
@@ -83,7 +68,7 @@
             <role>developer</role>
           </roles>
        </developer>
-       
+
        <developer>
           <id>beercan1989</id>
           <name>James Bacon</name>
@@ -93,7 +78,7 @@
             <role>developer</role>
           </roles>
         </developer>
-		  
+
     </developers>
 
 	<contributors>
@@ -104,49 +89,35 @@
 			</roles>
 		</contributor>
 	</contributors>
-    
+
     <properties>
 
-
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.11</junit.version>
-        
+
         <guava.version>10.0</guava.version>
         <mockito.version>1.9.0-rc1</mockito.version>
 
-     
         <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
         <sonar.phase>verify</sonar.phase>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 
         <sonar.jacoco.jar>${basedir}/jacoco/jacocoagent.jar</sonar.jacoco.jar>
         <sonar.jacoco.reportPath>${basedir}/target/jacoco.exec</sonar.jacoco.reportPath>
-	
+
         <xstream.version>1.4.2</xstream.version>
 
-        <compileSource>1.5</compileSource>
-        <compileTarget>1.5</compileTarget>
-		<!-- THESE PROPERTIES NEED TO BE DEFINED IN AN ACTIVE PROFILE IN SETTINGS.XML 
-			EG. <nexus.snapshot.artifacts>snapshots</nexus.snapshot.artifacts> <nexus.release.artifacts>releases</nexus.release.artifacts> 
-        <nexus.snapshot.url>http://someserver.com/${nexus.snapshot.artifacts}/</nexus.snapshot.url>
-        <nexus.releases.url>http://someserver.com/${nexus.release.artifacts}/</nexus.releases.url>
-		<substeps-core.scm>scm:git:git://github.com/${your username}/substeps-core.git</substeps-core.scm>
-			<substeps-core.scm.url></substeps-core.scm.url> -->
     </properties>
 
-
-    
-
     <dependencies>
-    
+
 	    <dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>
 			<version>${hamcrest.version}</version>
 			<scope>test</scope>
 		</dependency>
-	            
+
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>
@@ -169,7 +140,6 @@
         </dependency>
 
 
-
         <dependency>
             <groupId>velocity</groupId>
             <artifactId>velocity</artifactId>
@@ -187,7 +157,7 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
         </dependency>
-        
+
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -251,34 +221,34 @@
             <artifactId>xstream</artifactId>
             <version>${xstream.version}</version>
         </dependency>
-        
+
         <dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.3.1</version>
 		</dependency>
-            
+
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 			<version>2.1</version>
 		</dependency>
-		            
+
     </dependencies>
 
 
 
     <build>
         <finalName>${project.artifactId}</finalName>
+
         <plugins>
-
             <plugin>
-
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version>
+
 				<executions>
 					<execution>
+                        <id>create-test-jar</id>
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
@@ -286,35 +256,12 @@
 				</executions>
 			</plugin>
 
-			<plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-<!--                    <inherit>true</inherit>-->
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.3.2</version>
-
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-
-            </plugin>
-            
-			<!-- need to exclude this test as it is just used for manual testing, 
+			<!-- need to exclude this test as it is just used for manual testing,
 				the actual tests are covered by the maven plugin above -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.6</version>
+
                 <configuration>
                     <includes>
                         <include>**/*Test.java</include>
@@ -324,7 +271,7 @@
                         <exclude>**/BugFeaturesJunit.java</exclude>
                     </excludes>
                 </configuration>
-            </plugin>            
+            </plugin>
 
         </plugins>
     </build>
@@ -335,7 +282,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.7.2</version>
+
                 <configuration>
                     <outputDirectory>${basedir}/target/newsite</outputDirectory>
                 </configuration>
@@ -344,7 +291,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>2.0.1</version>
+
                 <configuration>
                     <outputDirectory>${basedir}/target/newsite</outputDirectory>
                 </configuration>
@@ -354,7 +301,7 @@
     </reporting>
 
     <profiles>
-        
+
         <profile>
             <id>ccProfile</id>
 
@@ -366,29 +313,22 @@
                             <artifactId>maven-compiler-plugin</artifactId>
                             <configuration>
                                 <compilerArgument>-g</compilerArgument>
-                                <source>${compileSource}</source>
-                                <target>${compileTarget}</target>
+                                <source>${java.version}</source>
+                                <target>${java.version}</target>
                             </configuration>
                         </plugin>
                     </plugins>
-
                 </pluginManagement>
 
-
-
                 <plugins>
-
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.7.2</version>
                         <configuration>
                             <argLine>-javaagent:${sonar.jacoco.jar}=destfile=${sonar.jacoco.reportPath}</argLine>
                             <includes>
                                 <include>**/*.java</include>
                             </includes>
-
-
                         </configuration>
                     </plugin>
 
@@ -399,22 +339,19 @@
                 </plugins>
             </build>
         </profile>
-     
+
 		<profile>
 			<id>selfTestReport</id>
 			<activation>
-				<activeByDefault>false</activeByDefault> <!-- RB TODO This can be enabled once a stable version has been released -->
+				<activeByDefault>false</activeByDefault><!-- TODO - Move to relevant project -->
 			</activation>
 
 			<build>
-
 				<plugins>
 					<plugin>
-
 						<groupId>com.technophobia.substeps</groupId>
 						<artifactId>substeps-maven-plugin</artifactId>
-                          <version>${project.version}</version>
-
+                        <version>${project.version}</version>
 
 						<executions>
 
@@ -424,7 +361,6 @@
 								<goals>
 									<goal>run-features</goal>
 								</goals>
-
 
 								<configuration>
 									<executionConfigs>
@@ -448,9 +384,7 @@
 										<reportTitle>Substeps Report - ${project.version} </reportTitle>
 
 									</executionReportBuilder>
-
 								</configuration>
-
 							</execution>
 							<execution>
 								<id>SubSteps Test</id>
@@ -459,9 +393,7 @@
 									<goal>run-features</goal>
 								</goals>
 
-
 								<configuration>
-
 									<executionConfigs>
 										<executionConfig>
 											<description>Test the report generation</description>
@@ -476,9 +408,7 @@
 											</stepImplementationClassNames>
 										</executionConfig>
 									</executionConfigs>
-
 								</configuration>
-
 							</execution>
 						</executions>
 
@@ -494,47 +424,13 @@
 			</build>
 
 			<dependencies>
-
 				<!-- Following dependencies added to self test the report -->
-
 				<dependency>
 					<groupId>com.technophobia.substeps</groupId>
 					<artifactId>webdriver-substeps</artifactId>
-					<version>1.1.2</version>
+					<version>1.1.3</version>
 				</dependency>
-
 			</dependencies>
-
 		</profile>
-
-        <!-- A profile used by default for internal dev, using the repos set up in proeprties defined above, rather than the OSS nexus repos -->
-        <profile>
-            <id>internalDev</id>
-
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>${nexus.snapshot.artifacts}</id>
-                    <name>${nexus.snapshot.artifacts}</name>
-                    <url>${nexus.snapshot.url}</url>
-                    <uniqueVersion>false</uniqueVersion>
-                </snapshotRepository>
-                <repository>
-                    <id>${nexus.release.artifacts}</id>
-                    <name>${nexus.release.artifacts}</name>
-                    <url>${nexus.releases.url}</url>
-                </repository>
-            </distributionManagement>
-
-        </profile>
-
-
     </profiles>
-
-    <scm>
-        <connection>${substeps-core.scm}</connection>
-        <developerConnection>${substeps-core.scm}</developerConnection>
-        <url>${substeps-core.scm.url}</url>
-      <tag>HEAD</tag>
-    </scm>
-
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,53 +12,41 @@
 
     <name>SubSteps Core</name>
 
-    <properties>
-        <hamcrest.version>1.3</hamcrest.version>
-        <junit.version>4.11</junit.version>
-
-        <guava.version>10.0</guava.version>
-        <mockito.version>1.9.0-rc1</mockito.version>
-
-        <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
-        <sonar.phase>verify</sonar.phase>
-        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-
-        <sonar.jacoco.jar>${basedir}/jacoco/jacocoagent.jar</sonar.jacoco.jar>
-        <sonar.jacoco.reportPath>${basedir}/target/jacoco.exec</sonar.jacoco.reportPath>
-
-        <xstream.version>1.4.2</xstream.version>
-    </properties>
-
     <dependencies>
-
-	    <dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>${hamcrest.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>${hamcrest.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.technophobia.substeps</groupId>
-			<artifactId>substeps-core-api</artifactId>
-          <version>${project.version}</version>
-		</dependency>
-
         <dependency>
             <groupId>com.technophobia.substeps</groupId>
             <artifactId>substeps-core-api</artifactId>
-          <version>${project.version}</version>
-            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.technophobia.substeps</groupId>
+            <artifactId>substeps-core-api</artifactId>
             <type>test-jar</type>
         </dependency>
 
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>velocity</groupId>
@@ -71,89 +59,51 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
         </dependency>
-
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.1</version>
         </dependency>
-
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.6.4</version>
-            <scope>provided</scope>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.1</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.4</version>
-           <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-            <scope>test</scope>
-        </dependency>
-
+        <!-- Test Dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
+        </dependency>
+
+        <!-- Test Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-            <groupId>net.sourceforge.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>1.3.2</version>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
         </dependency>
-
-		<dependency>
-		    <groupId>commons-configuration</groupId>
-		    <artifactId>commons-configuration</artifactId>
-		    <version>1.8</version>
-		</dependency>
-
-        <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-            <version>${xstream.version}</version>
-        </dependency>
-
-        <dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.3.1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.1</version>
-		</dependency>
-
     </dependencies>
 
 
@@ -190,7 +140,6 @@
                     </excludes>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 
@@ -214,41 +163,13 @@
                 </configuration>
             </plugin>
         </plugins>
-
     </reporting>
 
     <profiles>
-
         <profile>
-            <id>ccProfile</id>
-
+            <id>sonar</id>
             <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <compilerArgument>-g</compilerArgument>
-                                <source>${java.version}</source>
-                                <target>${java.version}</target>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>-javaagent:${sonar.jacoco.jar}=destfile=${sonar.jacoco.reportPath}</argLine>
-                            <includes>
-                                <include>**/*.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>sonar-maven-plugin</artifactId>
@@ -258,17 +179,17 @@
         </profile>
 
 		<profile>
-			<id>selfTestReport</id>
-			<activation>
-				<activeByDefault>false</activeByDefault><!-- TODO - Move to relevant project -->
-			</activation>
+			<id>self-test-report</id> <!-- TODO - Review this placement -->
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
 
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>com.technophobia.substeps</groupId>
 						<artifactId>substeps-maven-plugin</artifactId>
-                        <version>${project.version}</version>
+                        <version>${stable.substeps.version}</version>
 
 						<executions>
 
@@ -280,6 +201,9 @@
 								</goals>
 
 								<configuration>
+                                    <runTestsInForkedVM>false</runTestsInForkedVM>
+                                    <!-- TODO: Fix problem that produces java.lang.ClassNotFoundException: com.technophobia.substeps.runner.ForkedProcessCloser$GracefullShutdownRunner -->
+
 									<executionConfigs>
 										<executionConfig>
 											<description>Runs tests which generate a report</description>
@@ -311,6 +235,9 @@
 								</goals>
 
 								<configuration>
+                                    <runTestsInForkedVM>false</runTestsInForkedVM>
+                                    <!-- TODO: Fix problem that produces java.lang.ClassNotFoundException: com.technophobia.substeps.runner.ForkedProcessCloser$GracefullShutdownRunner -->
+
 									<executionConfigs>
 										<executionConfig>
 											<description>Test the report generation</description>
@@ -330,24 +257,22 @@
 						</executions>
 
 						<dependencies>
+                            <!-- Following dependencies added to self test the report -->
+                            <dependency>
+                                <groupId>com.technophobia.substeps</groupId>
+                                <artifactId>webdriver-substeps</artifactId>
+                                <version>${stable.substeps.version}</version>
+                            </dependency>
+
 							<dependency>
 								<groupId>org.slf4j</groupId>
 								<artifactId>slf4j-log4j12</artifactId>
-								<version>1.6.4</version>
+                                <version>${slf4j.version}</version>
 							</dependency>
 						</dependencies>
 					</plugin>
 				</plugins>
 			</build>
-
-			<dependencies>
-				<!-- Following dependencies added to self test the report -->
-				<dependency>
-					<groupId>com.technophobia.substeps</groupId>
-					<artifactId>webdriver-substeps</artifactId>
-					<version>1.1.3</version>
-				</dependency>
-			</dependencies>
 		</profile>
     </profiles>
 </project>

--- a/core/src/main/java/com/technophobia/substeps/execution/.directory
+++ b/core/src/main/java/com/technophobia/substeps/execution/.directory
@@ -1,3 +1,0 @@
-[Dolphin]
-Timestamp=2012,11,28,11,43,16
-ViewMode=1

--- a/core/src/main/java/com/technophobia/substeps/helper/AssertHelper.java
+++ b/core/src/main/java/com/technophobia/substeps/helper/AssertHelper.java
@@ -1,0 +1,44 @@
+package com.technophobia.substeps.helper;
+
+/**
+ * Helper that contains extracted methods from Assert from JUnit.
+ */
+public class AssertHelper {
+
+    private AssertHelper() {
+    }
+
+    public static void fail(final String message) {
+        if (message == null) {
+            throw new AssertionError();
+        }
+
+        throw new AssertionError(message);
+    }
+
+    public static void assertTrue(final String message, final boolean condition) {
+        if (!condition) {
+            fail(message);
+        }
+    }
+
+    public static void assertTrue(final boolean condition) {
+        assertTrue(null, condition);
+    }
+
+    public static void assertFalse(final String message, final boolean condition) {
+        assertTrue(message, !condition);
+    }
+
+    public static void assertFalse(final boolean condition) {
+        assertFalse(null, condition);
+    }
+
+    public static void assertNotNull(final String message, final Object object) {
+        assertTrue(message, object != null);
+    }
+
+    public static void assertNotNull(final Object object) {
+        assertNotNull(null, object);
+    }
+}

--- a/core/src/main/java/com/technophobia/substeps/model/Scenario.java
+++ b/core/src/main/java/com/technophobia/substeps/model/Scenario.java
@@ -23,8 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.runner.Description;
-
 public class Scenario extends RootFeature {
 
     @Override
@@ -42,8 +40,6 @@ public class Scenario extends RootFeature {
     private int scenarioLineNumber;
     private int exampleKeysLineNumber;
 
-    private Description junitDescription;
-
     private int sourceStartOffset = -1;
     private int sourceStartLineNumber = -1;
 
@@ -60,21 +56,6 @@ public class Scenario extends RootFeature {
 
     public boolean hasBackground() {
         return this.background != null;
-    }
-
-    /**
-     * @return the junitDescription
-     */
-    public Description getJunitDescription() {
-        return this.junitDescription;
-    }
-
-    /**
-     * @param junitDescription
-     *            the junitDescription to set
-     */
-    public void setJunitDescription(final Description junitDescription) {
-        this.junitDescription = junitDescription;
     }
 
     public String getDescription() {

--- a/core/src/main/java/com/technophobia/substeps/report/DefaultExecutionReportBuilder.java
+++ b/core/src/main/java/com/technophobia/substeps/report/DefaultExecutionReportBuilder.java
@@ -38,6 +38,7 @@ import java.util.Properties;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import com.technophobia.substeps.helper.AssertHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -46,7 +47,6 @@ import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +125,7 @@ public class DefaultExecutionReportBuilder extends ExecutionReportBuilder {
                 FileUtils.deleteDirectory(reportDir);
             }
 
-            Assert.assertTrue("failed to create directory: " + reportDir, reportDir.mkdirs());
+            AssertHelper.assertTrue("failed to create directory: " + reportDir, reportDir.mkdirs());
 
             copyStaticResources(reportDir);
 

--- a/core/src/main/java/com/technophobia/substeps/runner/ExecutionConfigWrapper.java
+++ b/core/src/main/java/com/technophobia/substeps/runner/ExecutionConfigWrapper.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import org.junit.Assert;
+import com.technophobia.substeps.helper.AssertHelper;
 
 import com.technophobia.substeps.model.SubSteps.StepImplementations;
 
@@ -76,7 +76,7 @@ public class ExecutionConfigWrapper extends ExecutionConfigDecorator {
                 stepImplementationClassList.add(implClass);
 
             } catch (final ClassNotFoundException e) {
-                Assert.fail("ClassNotFoundException: " + e.getMessage());
+                AssertHelper.fail("ClassNotFoundException: " + e.getMessage());
             }
         }
         return stepImplementationClassList;
@@ -108,12 +108,11 @@ public class ExecutionConfigWrapper extends ExecutionConfigDecorator {
                     if (IExecutionListener.class.isAssignableFrom(implClass)) {
                         notifierClassList.add((Class<? extends IExecutionListener>) implClass);
                     } else {
-
-                        Assert.fail("Execution Listener does not extend com.technophobia.substeps.runner.INotifier");
+                        AssertHelper.fail("Execution Listener does not extend com.technophobia.substeps.runner.INotifier");
                     }
 
                 } catch (final ClassNotFoundException e) {
-                    Assert.fail("ClassNotFoundException: " + e.getMessage());
+                    AssertHelper.fail("ClassNotFoundException: " + e.getMessage());
                 }
             }
         }

--- a/core/src/main/java/com/technophobia/substeps/runner/FeatureFileParser.java
+++ b/core/src/main/java/com/technophobia/substeps/runner/FeatureFileParser.java
@@ -28,12 +28,12 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import junit.framework.Assert;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
+
+import com.technophobia.substeps.helper.AssertHelper;
 import com.technophobia.substeps.model.Background;
 import com.technophobia.substeps.model.FeatureFile;
 import com.technophobia.substeps.model.Scenario;
@@ -64,7 +64,7 @@ public class FeatureFileParser {
         final FeatureFile ff = new FeatureFile();
         ff.setSourceFile(featureFile);
 
-        Assert.assertTrue("Feature file: " + featureFile.getAbsolutePath() + " does not exist!", featureFile.exists());
+        AssertHelper.assertTrue("Feature file: " + featureFile.getAbsolutePath() + " does not exist!", featureFile.exists());
 
         readFeatureFile(featureFile);
 

--- a/core/src/main/java/com/technophobia/substeps/runner/TestParameters.java
+++ b/core/src/main/java/com/technophobia/substeps/runner/TestParameters.java
@@ -23,10 +23,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.technophobia.substeps.helper.AssertHelper;
 import com.technophobia.substeps.model.FeatureFile;
 import com.technophobia.substeps.model.Scenario;
 import com.technophobia.substeps.model.Syntax;
@@ -76,8 +76,8 @@ public class TestParameters {
         log.debug("Current dir is: " + f.getAbsolutePath());
 
         if (failOnNoFeatures) {
-            Assert.assertNotNull("No Feature files found!", featureFileList);
-            Assert.assertFalse("No Feature files found!", featureFileList.isEmpty());
+            AssertHelper.assertNotNull("No Feature files found!", featureFileList);
+            AssertHelper.assertFalse("No Feature files found!", featureFileList.isEmpty());
         } else if (featureFileList == null) {
             featureFileList = Collections.emptyList();
         }

--- a/core/src/main/java/com/technophobia/substeps/runner/syntax/ClassAnalyser.java
+++ b/core/src/main/java/com/technophobia/substeps/runner/syntax/ClassAnalyser.java
@@ -20,8 +20,7 @@ package com.technophobia.substeps.runner.syntax;
 
 import java.lang.reflect.Method;
 
-import org.junit.Assert;
-
+import com.technophobia.substeps.helper.AssertHelper;
 import com.technophobia.substeps.model.StepImplementation;
 import com.technophobia.substeps.model.SubSteps.AdditionalStepImplementations;
 import com.technophobia.substeps.model.SubSteps.Step;
@@ -55,7 +54,7 @@ public class ClassAnalyser {
             final String stepValue = stepValueFrom(m);
 
             final StepImplementation impl = StepImplementation.parse(stepValue, loadedClass, m);
-            Assert.assertNotNull("unable to resolve the keyword / method for: " + stepValue + " in class: "
+            AssertHelper.assertNotNull("unable to resolve the keyword / method for: " + stepValue + " in class: "
                     + loadedClass, impl);
 
             syntax.addStepImplementation(impl);

--- a/core/src/test/resources/localhost.properties
+++ b/core/src/test/resources/localhost.properties
@@ -1,7 +1,7 @@
-base.url=target/test-classes/web/
+base.url=core/target/test-classes/web/
 
-#driver.type=HTMLUNIT
-driver.type=FIREFOX
+driver.type=HTMLUNIT
+#driver.type=FIREFOX
 #driver.type=CHROME
 # FIREFOX , HTMLUNIT, CHROME, or IE (ignoring security domains) - IE driver is very slow
 

--- a/glossary/pom.xml
+++ b/glossary/pom.xml
@@ -14,12 +14,7 @@
     <name>SubSteps Glossary Builder</name>
 
     <properties>
-        <hamcrest.version>1.3.RC2</hamcrest.version>
-        <guava.version>10.0</guava.version>
-        <mockito.version>1.9.0-rc1</mockito.version>
         <maven.version>2.2.1</maven.version>
-
-        <xstream.version>1.4.2</xstream.version>
     </properties>
 
     <build>
@@ -32,60 +27,85 @@
     </build>
 
     <dependencies>
-
         <dependency>
             <groupId>com.technophobia.substeps</groupId>
             <artifactId>substeps-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>com.technophobia.substeps</groupId>
             <artifactId>substeps-core-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <!-- JavaDoc Dependency -->
+        <dependency>
             <groupId>sun.jdk</groupId>
             <artifactId>tools</artifactId>
-            <version>1.6.31</version>
+            <version>${java.version}</version>
             <scope>system</scope>
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
         </dependency>
 
+        <!-- Maven Plugin Dependencies -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-project</artifactId>
             <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
             <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
         </dependency>
 
         <dependency>
@@ -94,51 +114,5 @@
             <version>1.0-beta-1</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.6.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.10</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-            <version>${xstream.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.2.2</version>
-        </dependency>
-
     </dependencies>
 </project>

--- a/glossary/pom.xml
+++ b/glossary/pom.xml
@@ -10,22 +10,8 @@
 	<artifactId>substeps-glossary-builder</artifactId>
 	<packaging>maven-plugin</packaging>
 
-	
 	<name>SubSteps Glossary Builder</name>
 
-   <organization>
-        <name>Technophobia Ltd</name>
-        <url>www.technophobia.com/</url>
-    </organization>
-
-    <licenses>
-        <license>
-            <name>LGPL 3.0 license</name>
-            <url>http://www.opensource.org/licenses/lgpl-3.0.html</url>
-            <distribution>manual</distribution>
-      </license>
-    </licenses>
-    
     <developers>
    
         <developer>
@@ -50,98 +36,44 @@
     </developers>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<hamcrest.version>1.3.RC2</hamcrest.version>
 		<guava.version>10.0</guava.version>
 		<mockito.version>1.9.0-rc1</mockito.version>
 		<maven.version>2.2.1</maven.version>
-
 		
         <xstream.version>1.4.2</xstream.version>
-        <!--  
-        
-        THESE PROPERTIES NEED TO BE DEFINED IN AN ACTIVE PROFILE IN SETTINGS.XML 
-        
-        <substeps-glossary.scm>scm:git:git://github.com/${your username}/substeps-glossary.git<substeps-glossary.scm>
-        <substeps-glossary.scm.url> <substeps-glossary.scm.url>
-        
-		<nexus.snapshot.artifacts>internalsnapshots</nexus.snapshot.artifacts>
-		<nexus.release.artifacts>internalreleases</nexus.release.artifacts>
-        
-          <nexus.snapshot.url>http://someserver.com/${nexus.snapshot.artifacts}/</nexus.snapshot.url>
-        <nexus.releases.url>http://someserver.com/${nexus.release.artifacts}/</nexus.releases.url>
-        
-        -->
 	</properties>
-
-
 
 	<build>
 		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
-					<inherit>true</inherit>
-					<encoding>${project.build.sourceEncoding}</encoding>
-				</configuration>
-			</plugin>
-
 			<plugin>
 				<groupId>org.codehaus.plexus</groupId>
 				<artifactId>plexus-component-metadata</artifactId>
-				<version>1.5.5</version>
 
 				<executions>
 					<execution>
+						<id>generate-metadata</id>
 						<goals>
 							<goal>generate-metadata</goal>
 						</goals>
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
-   <profiles>
-        
-        <!-- A profile used by default for internal dev, using the repos set up in proeprties defined above, rather than the OSS nexus repos -->    
-        <profile>
-            <id>internalDev</id>
-             
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>${nexus.snapshot.artifacts}</id>
-                    <name>${nexus.snapshot.artifacts}</name>
-                    <url>${nexus.snapshot.url}</url>
-                    <uniqueVersion>false</uniqueVersion>
-                </snapshotRepository>
-                <repository>
-                    <id>${nexus.release.artifacts}</id>
-                    <name>${nexus.release.artifacts}</name>
-                    <url>${nexus.releases.url}</url>
-                </repository>
-            </distributionManagement>
-            
-        </profile>
-    </profiles>
 
 	<dependencies>
 
 		<dependency>
 			<groupId>com.technophobia.substeps</groupId>
 			<artifactId>substeps-core</artifactId>
-          <version>${project.version}</version>
+            <version>${project.version}</version>
 		</dependency>
 
         <dependency>
-                <groupId>com.technophobia.substeps</groupId>
-                <artifactId>substeps-core-api</artifactId>
-          <version>${project.version}</version>
+            <groupId>com.technophobia.substeps</groupId>
+            <artifactId>substeps-core-api</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
 		<dependency>
@@ -214,7 +146,6 @@
 			<scope>test</scope>
 		</dependency>
 
-
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -227,7 +158,6 @@
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>
 		</dependency>
-
 
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
@@ -242,13 +172,4 @@
 		</dependency>
 
 	</dependencies>
-
-    <scm>
-        
-        <connection>${substeps-glossary.scm}</connection>
-        <developerConnection>${substeps-glossary.scm}</developerConnection>
-        <url>${substeps-glossary.scm.url}</url>
-    </scm>
-
-
 </project>

--- a/glossary/pom.xml
+++ b/glossary/pom.xml
@@ -1,5 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.technophobia.substeps</groupId>
@@ -7,68 +8,36 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-	<artifactId>substeps-glossary-builder</artifactId>
-	<packaging>maven-plugin</packaging>
+    <artifactId>substeps-glossary-builder</artifactId>
+    <packaging>maven-plugin</packaging>
 
-	<name>SubSteps Glossary Builder</name>
+    <name>SubSteps Glossary Builder</name>
 
-    <developers>
-   
-        <developer>
-          <id>ianmoore</id>
-          <name>Ian Moore</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>architect</role>
-            <role>developer</role>
-          </roles>
-        </developer>
+    <properties>
+        <hamcrest.version>1.3.RC2</hamcrest.version>
+        <guava.version>10.0</guava.version>
+        <mockito.version>1.9.0-rc1</mockito.version>
+        <maven.version>2.2.1</maven.version>
 
-        <developer>
-          <id>rickybarefield</id>
-          <name>Ricky Barefield</name>
-          <organization>Technophobia</organization>
-          <roles> 
-            <role>developer</role>
-          </roles>
-        </developer>
-  
-    </developers>
-
-	<properties>
-		<hamcrest.version>1.3.RC2</hamcrest.version>
-		<guava.version>10.0</guava.version>
-		<mockito.version>1.9.0-rc1</mockito.version>
-		<maven.version>2.2.1</maven.version>
-		
         <xstream.version>1.4.2</xstream.version>
-	</properties>
+    </properties>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.codehaus.plexus</groupId>
-				<artifactId>plexus-component-metadata</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
-				<executions>
-					<execution>
-						<id>generate-metadata</id>
-						<goals>
-							<goal>generate-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+    <dependencies>
 
-	<dependencies>
-
-		<dependency>
-			<groupId>com.technophobia.substeps</groupId>
-			<artifactId>substeps-core</artifactId>
+        <dependency>
+            <groupId>com.technophobia.substeps</groupId>
+            <artifactId>substeps-core</artifactId>
             <version>${project.version}</version>
-		</dependency>
+        </dependency>
 
         <dependency>
             <groupId>com.technophobia.substeps</groupId>
@@ -76,88 +45,88 @@
             <version>${project.version}</version>
         </dependency>
 
-		<dependency>
-		    <groupId>sun.jdk</groupId>
-		    <artifactId>tools</artifactId>
-		    <version>1.6.31</version>
-		    <scope>system</scope>
-		    <systemPath>${java.home}/../lib/tools.jar</systemPath>
-		  </dependency>
+        <dependency>
+            <groupId>sun.jdk</groupId>
+            <artifactId>tools</artifactId>
+            <version>1.6.31</version>
+            <scope>system</scope>
+            <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-artifact</artifactId>
-			<version>${maven.version}</version>
-             <scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-plugin-api</artifactId>
-			<version>${maven.version}</version>
-             <scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>${maven.version}</version>
-             <scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-model</artifactId>
-			<version>${maven.version}</version>
-             <scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-core</artifactId>
-			<version>${maven.version}</version>
-             <scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.maven.shared</groupId>
-			<artifactId>maven-plugin-testing-harness</artifactId>
-			<version>1.0-beta-1</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.6.4</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>${hamcrest.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>${hamcrest.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.10</version>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>1.0-beta-1</version>
             <scope>test</scope>
-		</dependency>
+        </dependency>
 
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.6.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
@@ -166,10 +135,10 @@
         </dependency>
 
         <dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.2.2</version>
-		</dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.2.2</version>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,21 @@
         <java.version>1.6</java.version>
         <java.signature.artifact>java16-sun</java.signature.artifact>
         <java.signature.version>1.10</java.signature.version>
+
+        <stable.substeps.version>1.1.3</stable.substeps.version>
+
+        <slf4j.version>1.6.4</slf4j.version>
+
+        <junit.version>4.11</junit.version>
+        <hamcrest.version>1.3</hamcrest.version>
+        <mockito.version>1.9.0</mockito.version>
+
+        <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
+        <sonar.phase>verify</sonar.phase>
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+
+        <sonar.jacoco.jar>${project.basedir}/jacoco/jacocoagent.jar</sonar.jacoco.jar>
+        <sonar.jacoco.reportPath>${project.basedir}/target/jacoco.exec</sonar.jacoco.reportPath>
     </properties>
 
     <distributionManagement>
@@ -122,6 +137,132 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.technophobia.substeps</groupId>
+                <artifactId>substeps-core-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.technophobia.substeps</groupId>
+                <artifactId>substeps-core-api</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.technophobia.substeps</groupId>
+                <artifactId>substeps-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.technophobia.substeps</groupId>
+                <artifactId>substeps-core</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.technophobia.substeps</groupId>
+                <artifactId>substeps-runner-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.technophobia.substeps</groupId>
+                <artifactId>substeps-glossary-builder</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.technophobia.substeps</groupId>
+                <artifactId>substeps-junit-runner</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.technophobia.substeps</groupId>
+                <artifactId>substeps-maven-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.technophobia.substeps</groupId>
+                <artifactId>substeps-ant-runner</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-configuration</groupId>
+                <artifactId>commons-configuration</artifactId>
+                <version>1.8</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.thoughtworks.xstream</groupId>
+                <artifactId>xstream</artifactId>
+                <version>1.4.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sourceforge.findbugs</groupId>
+                <artifactId>annotations</artifactId>
+                <version>1.3.2</version>
+            </dependency>
+
+            <!-- Logging Dependencies -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.16</version>
+            </dependency>
+
+            <!-- Test Dependencies -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <finalName>${project.artifactId}</finalName>
@@ -282,6 +423,38 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>sonar</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+
+                            <configuration>
+                                <compilerArgument>-g</compilerArgument>
+                                <source>${java.version}</source>
+                                <target>${java.version}</target>
+                            </configuration>
+                        </plugin>
+
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+
+                            <configuration>
+                                <argLine>-javaagent:${sonar.jacoco.jar}=destfile=${sonar.jacoco.reportPath}</argLine>
+                                <includes>
+                                    <include>**/*.java</include>
+                                </includes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
         <profile>
             <id>release</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.technophobia.substeps</groupId>
@@ -7,43 +8,38 @@
     <packaging>pom</packaging>
 
     <name>SubSteps Framework</name>
+    <description>The core project of SubSteps</description>
+    <url>https://github.com/G2G3Digital/substeps-framework</url>
 
-
-    <modules>
-      <module>api</module>
-      <module>core</module>
-      <module>runner</module>
-      <module>glossary</module>  
-    </modules>
-
-    <properties>
-
-    </properties>
-
-    
-    <organization>
-        <name>Technophobia Ltd</name>
-        <url>www.technophobia.com/</url>
-    </organization>
+    <scm>
+        <connection>scm:git:git@github.com:G2G3Digital/substeps-framework.git</connection>
+        <developerConnection>scm:git:git@github.com:G2G3Digital/substeps-framework.git</developerConnection>
+        <url>git@github.com:G2G3Digital/substeps-framework.git</url>
+    </scm>
 
     <licenses>
         <license>
             <name>LGPL 3.0 license</name>
             <url>http://www.opensource.org/licenses/lgpl-3.0.html</url>
             <distribution>manual</distribution>
-      </license>
+        </license>
     </licenses>
-    
+
+    <organization>
+        <name>Technophobia Ltd</name>
+        <url>www.technophobia.com/</url>
+    </organization>
+
     <developers>
-   
+
         <developer>
-          <id>ianmoore</id>
-          <name>Ian Moore</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>architect</role>
-            <role>developer</role>
-          </roles>
+            <id>ianmoore</id>
+            <name>Ian Moore</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>architect</role>
+                <role>developer</role>
+            </roles>
         </developer>
 
         <developer>
@@ -55,8 +51,209 @@
                 <role>developer</role>
             </roles>
         </developer>
-	  
+
     </developers>
 
+    <modules>
+        <module>api</module>
+        <module>core</module>
+        <module>runner</module>
+        <module>glossary</module>
+    </modules>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.6</java.version>
+        <java.signature.artifact>java16-sun</java.signature.artifact>
+        <java.signature.version>1.10</java.signature.version>
+    </properties>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <!-- Basic & Version Configuration -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.3</version>
+
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                        <encoding>${project.build.sourceEncoding}</encoding>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.14</version>
+
+                    <configuration>
+                        <signature>
+                            <groupId>org.codehaus.mojo.signature</groupId>
+                            <artifactId>${java.signature.artifact}</artifactId>
+                            <version>${java.signature.version}</version>
+                        </signature>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>ensure-java-api-compatibility</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.6</version>
+
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>ossrh</serverId>
+                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        <tags>
+                            <javaVersion>${java.version}</javaVersion>
+                        </tags>
+
+                        <!-- TODO: Add Travis-CI configuration for OSSRH access -->
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+
+                    <configuration>
+                        <tagNameFormat>@{project.version}</tagNameFormat>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <releaseProfiles>release</releaseProfiles>
+                        <goals>deploy</goals>
+
+                        <!-- TODO: Add Travis-CI configuration for SCM access -->
+                    </configuration>
+                </plugin>
+
+                <!-- Just Version Configuration -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.19</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-report-plugin</artifactId>
+                    <version>2.19</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>2.7.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-metadata</artifactId>
+                    <version>1.6</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <!-- Release Configuration -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+
+                                <!-- TODO: Add Travis-CI configuration for GPG access -->
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
     </organization>
 
     <developers>
-
         <developer>
             <id>ianmoore</id>
             <name>Ian Moore</name>
@@ -53,6 +52,55 @@
         </developer>
 
     </developers>
+
+    <contributors>
+        <contributor>
+            <name>Iain Rawson</name>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </contributor>
+
+        <contributor>
+            <name>Stu Forbes</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </contributor>
+
+        <contributor>
+            <name>Ricky Barefield</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </contributor>
+
+        <contributor>
+            <name>Rory Gibson</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </contributor>
+
+        <contributor>
+            <name>Peter Phillips</name>
+            <organization>Greenthistle.com</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </contributor>
+
+        <contributor>
+            <name>Dave Moss</name>
+            <organization>Technophobia</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </contributor>
+    </contributors>
 
     <modules>
         <module>api</module>
@@ -76,6 +124,8 @@
     </distributionManagement>
 
     <build>
+        <finalName>${project.artifactId}</finalName>
+
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -156,6 +206,20 @@
                         <!-- TODO: Add Travis-CI configuration for SCM access -->
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-metadata</artifactId>
+                    <version>1.6</version>
+
+                    <executions>
+                        <execution>
+                            <id>generate-metadata</id>
+                            <goals>
+                                <goal>generate-metadata</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
                 <!-- Just Version Configuration -->
                 <plugin>
@@ -199,9 +263,19 @@
                     <version>2.7.1</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.plexus</groupId>
-                    <artifactId>plexus-component-metadata</artifactId>
-                    <version>1.6</version>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.10</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>3.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/runner/Ant/pom.xml
+++ b/runner/Ant/pom.xml
@@ -9,15 +9,10 @@
 
     <artifactId>substeps-ant-runner</artifactId>
 
-    <packaging>jar</packaging>
-
-
     <name>SubSteps Ant Runner</name>
-    
     <description>An ant task for substeps</description> 
 
     <dependencies>
-
 	    <dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
@@ -28,8 +23,6 @@
           <groupId>com.technophobia.substeps</groupId>
           <artifactId>substeps-runner-common</artifactId>
         </dependency>
-
-		            
     </dependencies>
 
 </project>

--- a/runner/Common/pom.xml
+++ b/runner/Common/pom.xml
@@ -9,10 +9,7 @@
 
     <artifactId>substeps-runner-common</artifactId>
 
-    <packaging>jar</packaging>
-
     <name>SubSteps Runner Common</name>
-    
     <description>Contains common components for running substeps</description>  
 
 </project>

--- a/runner/Junit/pom.xml
+++ b/runner/Junit/pom.xml
@@ -7,14 +7,9 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-
 	<artifactId>substeps-junit-runner</artifactId>
 
-	<packaging>jar</packaging>
-
-
 	<name>SubSteps JUnit Runner</name>
-
 	<description>A junit runner for substeps</description>
 
 	<build>
@@ -25,52 +20,41 @@
 
 				<executions>
 					<execution>
+						<id>extract-core-substep-test-code</id>
+
 						<phase>test-compile</phase>
 						<goals>
 							<goal>unpack-dependencies</goal>
 						</goals>
 
 						<configuration>
-
 							<includeArtifactIds>substeps-core</includeArtifactIds>
 							<includeTypes>test-jar</includeTypes>
 							<outputDirectory>${project.build.directory}/core-tests</outputDirectory>
 						</configuration>
-
 					</execution>
 				</executions>
-
 			</plugin>
-
 		</plugins>
-
 	</build>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>com.technophobia.substeps</groupId>
 			<artifactId>substeps-runner-common</artifactId>
 		</dependency>
 
-		<!-- Although this has a dependency on core it is important that the scope 
-			is TEST -->
-
-
+		<!-- Although this has a dependency on core it is important that the scope is TEST -->
 		<dependency>
 			<groupId>com.technophobia.substeps</groupId>
 			<artifactId>substeps-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-
-		<dependency>
+        <dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-
 	</dependencies>
 
 </project>

--- a/runner/Maven/pom.xml
+++ b/runner/Maven/pom.xml
@@ -1,5 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.technophobia.substeps</groupId>
@@ -7,135 +8,105 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
+    <artifactId>substeps-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
 
-	<artifactId>substeps-maven-plugin</artifactId>
-	<packaging>maven-plugin</packaging>
+    <name>SubSteps Maven Plugin</name>
+    <description>A maven plugin for the substeps BDD framework</description>
 
+    <properties>
+        <maven.version>2.2.1</maven.version>
+    </properties>
 
-	<name>SubSteps Maven Plugin</name>
+    <dependencies>
 
-	<properties>
-		<maven.version>2.2.1</maven.version>
-	</properties>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>1.0-beta-1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
 
-	<description>A maven plugin for the substeps BDD framework</description>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>com.technophobia.substeps</groupId>
+            <artifactId>substeps-runner-common</artifactId>
+        </dependency>
 
-	<dependencies>
+    </dependencies>
 
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-artifact</artifactId>
-			<version>${maven.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-plugin-api</artifactId>
-			<version>${maven.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>${maven.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-model</artifactId>
-			<version>${maven.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven.shared</groupId>
-			<artifactId>maven-plugin-testing-harness</artifactId>
-			<version>1.0-beta-1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>${hamcrest.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>${hamcrest.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.technophobia.substeps</groupId>
-			<artifactId>substeps-runner-common</artifactId>
-		</dependency>
-
-	</dependencies>
-
-	<build>
-		<!--pluginManagement>
-
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-site-plugin</artifactId>
-					<version>2.1</version>
-				</plugin>
-			</plugins>
-		</pluginManagement-->
-		<plugins>
-			<plugin>
-				<groupId>org.codehaus.plexus</groupId>
-				<artifactId>plexus-component-metadata</artifactId>
-				<version>1.5.5</version>
-
-				<executions>
-					<execution>
-						<goals>
-							<goal>generate-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 
-	<reporting>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
 
-		<plugins>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-plugin-plugin</artifactId>
-				<version>2.6</version>
-
-				<reportSets>
-					<reportSet>
-						<reports>
-							<report>report</report>
-						</reports>
-					</reportSet>
-				</reportSets>
-
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.8</version>
-
-				<reportSets>
-					<reportSet>
-						<reports>
-							<report>index</report>
-						       
-						</reports>
-					</reportSet>
-				</reportSets>
-
-			</plugin>
-		</plugins>
-	</reporting>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>index</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/runner/Maven/pom.xml
+++ b/runner/Maven/pom.xml
@@ -19,7 +19,12 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.technophobia.substeps</groupId>
+            <artifactId>substeps-runner-common</artifactId>
+        </dependency>
 
+        <!-- Maven Plugin Dependencies -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
@@ -44,31 +49,22 @@
             <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
             <version>1.0-beta-1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.technophobia.substeps</groupId>
-            <artifactId>substeps-runner-common</artifactId>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -79,7 +75,6 @@
             </plugin>
         </plugins>
     </build>
-
 
     <reporting>
         <plugins>

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -7,167 +8,74 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-
     <artifactId>substeps-runner-parent</artifactId>
-
     <packaging>pom</packaging>
 
+    <name>SubSteps Runner Parent</name>
+    <description>Contains substeps runner projects</description>
+
     <modules>
-      <module>Common</module>
-      <module>Maven</module>
-      <module>Ant</module>
-      <module>Junit</module>
+        <module>Common</module>
+        <module>Maven</module>
+        <module>Ant</module>
+        <module>Junit</module>
     </modules>
 
     <properties>
-
-      <guava.version>10.0</guava.version>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <hamcrest.version>1.3.RC2</hamcrest.version>
-      <mockito.version>1.9.0-rc1</mockito.version>
+        <guava.version>10.0</guava.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <hamcrest.version>1.3.RC2</hamcrest.version>
+        <mockito.version>1.9.0-rc1</mockito.version>
     </properties>
 
-    <name>SubSteps Runner Parent</name>
-    
-    <description>Contains substeps runner projects</description>
-
-    <organization>
-        <name>Technophobia Ltd</name>
-        <url>http://www.technophobia.com/</url>
-    </organization>
-
-    <licenses>
-        <license>
-            <name>LGPL 3.0 license</name>
-            <url>http://www.opensource.org/licenses/lgpl-3.0.html</url>
-            <distribution>manual</distribution>
-      </license>
-    </licenses>
-    
-    <developers>
-   
-        <developer>
-          <id>ianmoore</id>
-          <name>Ian Moore</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>architect</role>
-            <role>developer</role>
-          </roles>
-        </developer>
-
-        <developer>
-          <id>rorygibson</id>
-          <name>Rory Gibson</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
-        </developer>
-
-        <developer>
-          <id>davemoss</id>
-          <name>Dave Moss</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
-        </developer>
-  
-       <developer>
-          <id>stuartforbes</id>
-          <name>Stu Forbes</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
-        </developer>
-
- 
-        <developer>
-          <id>rickybarefield</id>
-          <name>Ricky Barefield</name>
-          <organization>Technophobia</organization>
-          <roles>
-            <role>developer</role>
-          </roles>
-       </developer>
-       
-       <developer>
-          <id>beercan1989</id>
-          <name>James Bacon</name>
-          <organization>G2G3 Digital</organization>
-          <url>https://github.com/beercan1989</url>
-          <roles>
-            <role>developer</role>
-          </roles>
-        </developer>
-	  
-    </developers>
-
-	<contributors>
-		<contributor>
-			<name>Iain Rawson</name>
-			<roles>
-				<role>developer</role>
-			</roles>
-		</contributor>
-	</contributors>
-
     <dependencyManagement>
-      <dependencies>
-       
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>substeps-runner-common</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>substeps-core</artifactId>
-          <version>${project.version}</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-all</artifactId>
-          <version>${mockito.version}</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-          <version>${hamcrest.version}</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-library</artifactId>
-          <version>${hamcrest.version}</version>
-          <scope>test</scope>
-        </dependency>
-
-      </dependencies>
-
+        <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>substeps-runner-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>substeps-core</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
-     
 
     <dependencies>
-
         <dependency>
-          <groupId>com.technophobia.substeps</groupId>
-          <artifactId>substeps-core-api</artifactId>
-          <version>${project.version}</version>
+            <groupId>com.technophobia.substeps</groupId>
+            <artifactId>substeps-core-api</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.technophobia.substeps</groupId>
             <artifactId>substeps-core-api</artifactId>
-          <version>${project.version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
-
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -179,7 +87,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.6.4</version>
-           <scope>test</scope>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -205,81 +113,14 @@
             <groupId>net.sourceforge.findbugs</groupId>
             <artifactId>annotations</artifactId>
             <version>1.3.2</version>
-        </dependency> 
-	
+        </dependency>
 
         <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>substeps-core</artifactId>
-          <version>${project.version}</version>
-          <type>test-jar</type>
-          <scope>test</scope>
-        </dependency>     
+            <groupId>${project.groupId}</groupId>
+            <artifactId>substeps-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
-    <build>
-
-        <finalName>${project.artifactId}</finalName>        
-        <plugins>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <!--<inherit>true</inherit>-->
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.3.2</version>
-
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-
-            </plugin>
-            
-        </plugins>
-    </build>
-
-
-
-    <profiles>
-        
-	<!-- A profile used by default for internal dev, using the repos set up in proeprties defined above, rather than the OSS nexus repos -->    
-        <profile>
-            <id>internalDev</id>
-             
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>${nexus.snapshot.artifacts}</id>
-                    <name>${nexus.snapshot.artifacts}</name>
-                    <url>${nexus.snapshot.url}</url>
-                    <uniqueVersion>false</uniqueVersion>
-                </snapshotRepository>
-                <repository>
-                    <id>${nexus.release.artifacts}</id>
-                    <name>${nexus.release.artifacts}</name>
-                    <url>${nexus.releases.url}</url>
-                </repository>
-            </distributionManagement>
-            
-        </profile>
-
-    </profiles>
-
-    <scm>
-        <connection>${substeps-runner.scm}</connection>
-        <developerConnection>${substeps-runner.scm}</developerConnection>
-        <url>${substeps-runner.scm.url}</url>
-      <tag>HEAD</tag>
-  </scm>
-   
 </project>

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -21,106 +21,54 @@
         <module>Junit</module>
     </modules>
 
-    <properties>
-        <guava.version>10.0</guava.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hamcrest.version>1.3.RC2</hamcrest.version>
-        <mockito.version>1.9.0-rc1</mockito.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>substeps-runner-common</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>substeps-core</artifactId>
-                <version>${project.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>${hamcrest.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>${hamcrest.version}</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>com.technophobia.substeps</groupId>
             <artifactId>substeps-core-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.technophobia.substeps</groupId>
-            <artifactId>substeps-core-api</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-            <type>test-jar</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.6.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.4</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
-
         <dependency>
             <groupId>net.sourceforge.findbugs</groupId>
             <artifactId>annotations</artifactId>
-            <version>1.3.2</version>
         </dependency>
 
+
+        <!-- Logging Dependencies -->
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>substeps-core</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>com.technophobia.substeps</groupId>
+            <artifactId>substeps-core-api</artifactId>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.technophobia.substeps</groupId>
+            <artifactId>substeps-core</artifactId>
+            <type>test-jar</type>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
I've done a few things:
- Changes to the pom setup to use the framework root to handle dependency management.
- Enabled running of tests that now rely on the latest stable release, else we get cyclic references.
- Hopefully setup the substeps-framework pom as a possible parent for all substeps projects, around configuration for releases and such. 
- Removed the dependency for junit at compile from the substeps-core module, I'm expecting this to break something within substeps-webdriver.
- Moved all the meta data in the pom's to the root of the project.
- Minor version updating of hamcrest from 1.3RC1 to 1.3 in places to keep it the same version across modules.
- Added configuration for Travis-CI that I hope will cause it to upload snapshots when not building pull requests, I hope also once we setup Travis-CI with the credentials required.
